### PR TITLE
release 2.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,22 @@
-version: 2
+version: 2.1
+
 jobs:
   build:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk:8.0
     steps:
-      - run: apt-get update && apt-get install -y ssh git
+      - run:
+          name: Install SSH and Git
+          command: apt-get update && apt-get install -y ssh git
       - checkout
-      - run: cd src && dotnet build Castle.Sdk -c Release -f netstandard2.1
-      - run: cd src && dotnet test Tests
+      - run:
+          name: Build
+          command: cd src && dotnet build Castle.Sdk -c Release
+      - run:
+          name: Test
+          command: cd src && dotnet test Tests
+
+workflows:
+  build-and-test:
+    jobs:
+      - build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master/develop
 
+## 2.3.0 (2026-04-02)
+
+Added `scores` property to `RiskResponse`, exposing individual score breakdowns (e.g. `account_abuse`, `account_takeover`, `bot`) from the Risk API.
+
 ## 2.2.0 (2024-05-15)
 
 Added support for `skip_request_token_validation` and `skip_context_validation` options,

--- a/src/Castle.Sdk/Castle.Sdk.csproj
+++ b/src/Castle.Sdk/Castle.Sdk.csproj
@@ -4,7 +4,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/castle/castle-dotnet</PackageProjectUrl>
     <RootNamespace>Castle</RootNamespace>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <Authors>Castle</Authors>
     <Product>Castle .NET SDK</Product>
     <Description>Castle SDK for C# / .NET</Description>

--- a/src/Castle.Sdk/Messages/Responses/RiskResponse.cs
+++ b/src/Castle.Sdk/Messages/Responses/RiskResponse.cs
@@ -1,9 +1,14 @@
 using System;
 using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 
 namespace Castle.Messages.Responses
 {
 
+    public class ScoreItem
+    {
+        public float Score { get; set; }
+    }
     public class RiskResponse
     {
         public DeviceItem Device { get; set; }
@@ -11,6 +16,8 @@ namespace Castle.Messages.Responses
 
         public Policy Policy { get; set; }
         public JObject Signals { get; set; }
+
+       public Dictionary<string, ScoreItem> Scores { get; set; }
 
         // FailOver
         public ActionType Action { get; set; }

--- a/src/Tests/Json/When_deserializing_risk_response.cs
+++ b/src/Tests/Json/When_deserializing_risk_response.cs
@@ -1,0 +1,60 @@
+using Castle.Infrastructure.Json;
+using Castle.Messages.Responses;
+using FluentAssertions;
+using Xunit;
+
+namespace Tests.Json
+{
+    public class When_deserializing_risk_response
+    {
+        private const string RealApiResponse = @"{
+            ""risk"": 0.93,
+            ""policy"": {
+                ""action"": ""allow"",
+                ""id"": ""policy-123"",
+                ""name"": ""Default"",
+                ""revision_id"": ""rev-456""
+            },
+            ""scores"": {
+                ""account_abuse"": { ""score"": 0.12 },
+                ""account_takeover"": { ""score"": 0.05 },
+                ""bot"": { ""score"": 0.87 }
+            },
+            ""signals"": {
+                ""new_device"": {},
+                ""datacenter_ip"": {}
+            },
+            ""device"": {
+                ""token"": ""dev-token"",
+                ""fingerprint"": ""fp-123"",
+                ""risk"": 0.5,
+                ""created_at"": ""2026-01-01T00:00:00Z"",
+                ""last_seen_at"": ""2026-03-01T00:00:00Z""
+            }
+        }";
+
+        [Fact]
+        public void Should_deserialize_scores_from_api_response()
+        {
+            var result = JsonForCastle.DeserializeObject<RiskResponse>(RealApiResponse);
+
+            result.Scores.Should().NotBeNull();
+            result.Scores.Should().ContainKey("bot");
+            result.Scores.Should().ContainKey("account_abuse");
+            result.Scores.Should().ContainKey("account_takeover");
+            result.Scores["bot"].Score.Should().BeApproximately(0.87f, 0.01f);
+            result.Scores["account_abuse"].Score.Should().BeApproximately(0.12f, 0.01f);
+            result.Scores["account_takeover"].Score.Should().BeApproximately(0.05f, 0.01f);
+        }
+
+        [Fact]
+        public void Should_deserialize_risk_and_policy()
+        {
+            var result = JsonForCastle.DeserializeObject<RiskResponse>(RealApiResponse);
+
+            result.Risk.Should().BeApproximately(0.93f, 0.01f);
+            result.Policy.Should().NotBeNull();
+            result.Policy.Name.Should().Be("Default");
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Added scores property to RiskResponse, exposing individual score breakdowns (e.g. account_abuse, account_takeover, bot) from the Risk API
Bumped version to 2.3.0
Updated CHANGELOG

### Changes
RiskResponse now includes Dictionary<string, ScoreItem> Scores
New ScoreItem class with Score property
Applies to both /v1/risk and /v1/filter (shared response type)
Deserialization tests against realistic API payload